### PR TITLE
Cancel user warns

### DIFF
--- a/app/handlers/keyboards.py
+++ b/app/handlers/keyboards.py
@@ -11,6 +11,11 @@ class KarmaCancelCb(CallbackData, prefix="karma_cancel"):
     moderator_event_id: int | str
 
 
+class WarnCancelCb(CallbackData, prefix="warn_cancel"):
+    user_id: int
+    moderator_event_id: int
+
+
 def get_kb_karma_cancel(
         user: User, karma_event: KarmaEvent, rollback_karma: float, moderator_event: ModeratorEvent
 ) -> InlineKeyboardMarkup:
@@ -21,6 +26,16 @@ def get_kb_karma_cancel(
             karma_event_id=karma_event.id_,
             rollback_karma=f"{rollback_karma:.2f}",
             moderator_event_id=moderator_event.id_ if moderator_event is not None else "null",
+        ).pack()
+    )]])
+
+
+def get_kb_warn_cancel(user: User, moderator_event: ModeratorEvent):
+    return InlineKeyboardMarkup(inline_keyboard=[[InlineKeyboardButton(
+        text='Отменить',
+        callback_data=WarnCancelCb(
+            user_id=user.tg_id,
+            moderator_event_id=moderator_event.id_
         ).pack()
     )]])
 

--- a/app/handlers/moderator.py
+++ b/app/handlers/moderator.py
@@ -8,7 +8,7 @@ from aiogram.utils.text_decorations import html_decoration as hd
 from app.filters import HasTargetFilter, HasPermissions, BotHasPermissions
 from app.models.config import Config
 from app.models.db import Chat, User
-from app.services.moderation import warn_user, ro_user, ban_user, get_duration, cancel_warn_user
+from app.services.moderation import warn_user, ro_user, ban_user, get_duration, delete_moderator_event
 from app.services.remove_message import delete_message, remove_kb
 from app.services.user_info import get_user_info
 from app.utils.exceptions import TimedeltaParseError, ModerationError
@@ -158,8 +158,9 @@ async def cmd_ro_bot_not_admin(message: types.Message):
 
 @router.callback_query(kb.WarnCancelCb.filter())
 async def cancel_warn(callback_query: types.CallbackQuery, callback_data: kb.WarnCancelCb):
-    if callback_data.user_id != callback_query.from_user.id:
+    from_user = callback_query.from_user
+    if callback_data.user_id != from_user.id:
         return await callback_query.answer("Эта кнопка не для Вас", cache_time=3600)
-    await cancel_warn_user(callback_data.moderator_event_id)
+    await delete_moderator_event(callback_data.moderator_event_id, moderator=from_user)
     await callback_query.answer("Предупреждение было отменено", show_alert=True)
     await callback_query.message.delete()

--- a/app/services/moderation.py
+++ b/app/services/moderation.py
@@ -187,6 +187,13 @@ async def get_count_auto_restrict(
     ).count()
 
 
-async def cancel_warn_user(moderator_event_id: int):
+async def delete_moderator_event(moderator_event_id: int, moderator: User | None = None):
     moderator_event = await ModeratorEvent.get(id_=moderator_event_id)
+
+    logger.info(
+        '{moderator_event} was deleted {by}',
+        moderator_event=repr(moderator_event),
+        by='' if not moderator else f'by {moderator.username}'
+    )
+
     await moderator_event.delete()

--- a/app/services/moderation.py
+++ b/app/services/moderation.py
@@ -185,3 +185,8 @@ async def get_count_auto_restrict(
         moderator=bot_user, user=target, chat=chat,
         type_restriction__in=(TypeRestriction.karmic_ro.name, TypeRestriction.karmic_ban.name),
     ).count()
+
+
+async def cancel_warn_user(moderator_event_id: int):
+    moderator_event = await ModeratorEvent.get(id_=moderator_event_id)
+    await moderator_event.delete()


### PR DESCRIPTION
When a moderator gives a warn, a cancel button appears under a message. The logic of this button is almost the same as the button for canceling karma change