### PR TITLE
Add using chat type filters and new handlers for private

### DIFF
--- a/app/handlers/moderator.py
+++ b/app/handlers/moderator.py
@@ -1,20 +1,21 @@
 import asyncio
 
-from aiogram import types, F, Bot, Router
+from aiogram import Bot, F, Router, types
 from aiogram.exceptions import TelegramUnauthorizedError
 from aiogram.filters import Command
 from aiogram.utils.text_decorations import html_decoration as hd
 
-from app.filters import HasTargetFilter, HasPermissions, BotHasPermissions
+from app.filters import BotHasPermissions, HasPermissions, HasTargetFilter
 from app.models.config import Config
 from app.models.db import Chat, User
-from app.services.moderation import warn_user, ro_user, ban_user, get_duration, delete_moderator_event
+from app.services.moderation import (ban_user, delete_moderator_event,
+                                     get_duration, ro_user, warn_user)
 from app.services.remove_message import delete_message, remove_kb
 from app.services.user_info import get_user_info
-from app.utils.exceptions import TimedeltaParseError, ModerationError
+from app.utils.exceptions import ModerationError, TimedeltaParseError
 from app.utils.log import Logger
-from . import keyboards as kb
 
+from . import keyboards as kb
 
 logger = Logger(__name__)
 router = Router(name=__name__)
@@ -30,6 +31,14 @@ async def report(message: types.Message, bot: Bot):
     answer_template = "Спасибо за сообщение. Мы обязательно разберёмся. "
     admins_mention = await get_mentions_admins(message.chat, bot)
     await message.reply(answer_template + admins_mention + " ")
+
+
+@router.message(
+    F.chat.type == "private",
+    Command('report', 'admin', 'spam', prefix="/!@"),
+)
+async def report_private(message: types.Message):
+    await message.reply("Вы можете жаловаться на сообщения пользователей только в группах.")
 
 
 async def get_mentions_admins(chat: types.Chat, bot: Bot):
@@ -48,6 +57,7 @@ def need_notify_admin(admin: types.ChatMemberAdministrator | types.ChatMemberOwn
 
 
 @router.message(
+    F.chat.type.in_(["group", "supergroup"]),
     HasTargetFilter(),
     Command(commands=["ro", "mute"], prefix="!"),
     HasPermissions(can_restrict_members=True),
@@ -68,6 +78,15 @@ async def cmd_ro(message: types.Message, user: User, target: User, chat: Chat, b
 
 
 @router.message(
+    F.chat.type == "private",
+    Command(commands=["ro", "mute"], prefix="!"),
+)
+async def cmd_ro_private(message: types.Message):
+    await message.reply("Вы можете запрещать писать пользователям только в группах.")
+
+
+@router.message(
+    F.chat.type.in_(["group", "supergroup"]),
     HasTargetFilter(),
     Command(commands=["ban"], prefix="!"),
     HasPermissions(can_restrict_members=True),
@@ -88,6 +107,15 @@ async def cmd_ban(message: types.Message, user: User, target: User, chat: Chat, 
 
 
 @router.message(
+    F.chat.type == "private",
+    Command(commands=["ban"], prefix="!"),
+)
+async def cmd_ban_private(message: types.Message):
+    await message.reply("Вы можете блоировать пользователей только в группах.")
+
+
+@router.message(
+    F.chat.type.in_(["group", "supergroup"]),
     HasTargetFilter(),
     Command(commands=["w", "warn"], prefix="!"),
     HasPermissions(can_restrict_members=True),
@@ -114,7 +142,18 @@ async def cmd_warn(message: types.Message, chat: Chat, target: User, user: User,
     asyncio.create_task(remove_kb(msg, config.time_to_cancel_actions))
 
 
-@router.message(HasTargetFilter(can_be_same=True), Command("info", prefix='!'))
+@router.message(
+    F.chat.type == "private",
+    Command(commands=["w", "warn"], prefix="!"),
+)
+async def cmd_warn_private(message: types.Message):
+    await message.reply("Вы можете выдавать предупреждения пользователям только в группах.")
+
+
+@router.message(
+    F.chat.type.in_(["group", "supergroup"]),
+    HasTargetFilter(can_be_same=True), Command("info", prefix='!'),
+)
 async def get_info_about_user(message: types.Message, chat: Chat, target: User, config: Config, bot: Bot):
     info = await get_user_info(target, chat, config.date_format)
     target_karma = await target.get_karma(chat)
@@ -138,6 +177,15 @@ async def get_info_about_user(message: types.Message, chat: Chat, target: User, 
 
 
 @router.message(
+    F.chat.type == "private",
+    Command("info", prefix='!'),
+)
+async def get_info_about_user_private(message: types.Message):
+    await message.reply("Вы можете запрашивать информацию о пользователях только в группах.")
+
+
+@router.message(
+    F.chat.type.in_(["group", "supergroup"]),
     HasTargetFilter(),
     Command(commands=["ro", "mute", "ban"], prefix="!"),
     HasPermissions(can_restrict_members=True),
@@ -148,6 +196,7 @@ async def cmd_ro_bot_not_admin(message: types.Message):
 
 
 @router.message(
+    F.chat.type.in_(["group", "supergroup"]),
     Command(commands=["ro", "mute", "ban", "warn", "w"], prefix="!"),
     BotHasPermissions(can_delete_messages=True),
 )


### PR DESCRIPTION
If a user sends some commands in private chat, the bot got an error or just ignore the user. We can add new handlers for handles these commands and inform the user about that commands should be used in groups.