### PR TITLE
Fix unhandle handlers and check target user permissions

### DIFF
--- a/app/filters/__init__.py
+++ b/app/filters/__init__.py
@@ -1,7 +1,8 @@
 from app.utils.log import Logger
 
-from .karma_change import KarmaFilter
-from .tg_permissions import BotHasPermissions, HasPermissions
 from .has_target import HasTargetFilter
+from .karma_change import KarmaFilter
+from .tg_permissions import (BotHasPermissions, HasPermissions,
+                             TargetHasPermissions)
 
 logger = Logger(__name__)

--- a/app/filters/tg_permissions.py
+++ b/app/filters/tg_permissions.py
@@ -1,6 +1,6 @@
 # from https://github.com/aiogram/bot/blob/master/app/filters/has_permissions.py
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Union
+from typing import Any
 
 from aiogram import Bot, types
 from aiogram.filters import Filter
@@ -39,7 +39,7 @@ class HasPermissions(Filter):
             arg: True for arg in self.ARGUMENTS.values() if getattr(self, arg)
         }
 
-    def _get_cached_value(self, _message: types.Message) -> Optional[types.ChatMember]:
+    def _get_cached_value(self, _message: types.Message) -> types.ChatMember | None:
         return None  # TODO
 
     def _set_cached_value(self, _message: types.Message, _member: types.ChatMember):
@@ -59,7 +59,7 @@ class HasPermissions(Filter):
             self._set_cached_value(message, chat_member)
         return chat_member
 
-    async def __call__(self, message: types.Message, bot: Bot) -> Union[bool, Dict[str, Any]]:
+    async def __call__(self, message: types.Message, bot: Bot) -> bool | dict[str, Any]:
         chat_member = await self._get_chat_member(message, bot)
         if not chat_member:
             return False
@@ -71,7 +71,7 @@ class HasPermissions(Filter):
 
         return {self.PAYLOAD_ARGUMENT_NAME: chat_member}
 
-    def get_target_id(self, message: types.Message, bot: Bot) -> Optional[int]:
+    def get_target_id(self, message: types.Message, bot: Bot) -> int | None:
         return message.from_user.id
 
 
@@ -83,7 +83,7 @@ class TargetHasPermissions(HasPermissions):
     can_be_same: bool = False
     can_be_bot: bool = False
 
-    def get_target_id(self, message: types.Message, bot: Bot) -> Optional[int]:
+    def get_target_id(self, message: types.Message, bot: Bot) -> int | None:
         target_user = get_target_user(message, self.can_be_same, self.can_be_bot)
         if target_user is None:
             return None
@@ -107,5 +107,5 @@ class BotHasPermissions(HasPermissions):
     }
     PAYLOAD_ARGUMENT_NAME = "bot_member"
 
-    def get_target_id(self, message: types.Message, bot: Bot) -> Optional[int]:
+    def get_target_id(self, message: types.Message, bot: Bot) -> int | None:
         return bot.id

--- a/app/filters/tg_permissions.py
+++ b/app/filters/tg_permissions.py
@@ -1,9 +1,11 @@
 # from https://github.com/aiogram/bot/blob/master/app/filters/has_permissions.py
 from dataclasses import dataclass
-from typing import Any, Union, Dict
+from typing import Any, Dict, Optional, Union
 
-from aiogram import types, Bot
+from aiogram import Bot, types
 from aiogram.filters import Filter
+
+from app.services.find_target_user import get_target_user
 
 
 @dataclass
@@ -37,17 +39,19 @@ class HasPermissions(Filter):
             arg: True for arg in self.ARGUMENTS.values() if getattr(self, arg)
         }
 
-    def _get_cached_value(self, message: types.Message):
+    def _get_cached_value(self, _message: types.Message) -> Optional[types.ChatMember]:
         return None  # TODO
 
-    def _set_cached_value(self, message: types.Message, member: types.ChatMember):
+    def _set_cached_value(self, _message: types.Message, _member: types.ChatMember):
         return None  # TODO
 
     async def _get_chat_member(self, message: types.Message, bot: Bot):
-        chat_member: types.ChatMember = self._get_cached_value(message)
+        chat_member = self._get_cached_value(message)
         if chat_member is None:
             admins = await bot.get_chat_administrators(message.chat.id)
             target_user_id = self.get_target_id(message, bot)
+            if target_user_id is None:
+                return False
             try:
                 chat_member = next(filter(lambda member: member.user.id == target_user_id, admins))
             except StopIteration:
@@ -61,14 +65,29 @@ class HasPermissions(Filter):
             return False
         if chat_member.status == "creator":
             return chat_member
-        for permission, value in self.required_permissions.items():
+        for permission, _value in self.required_permissions.items():
             if not getattr(chat_member, permission):
                 return False
 
         return {self.PAYLOAD_ARGUMENT_NAME: chat_member}
 
-    def get_target_id(self, message: types.Message, bot: Bot) -> int:
+    def get_target_id(self, message: types.Message, _bot: Bot) -> Optional[int]:
         return message.from_user.id
+
+
+@dataclass
+class TargetHasPermissions(HasPermissions):
+    """
+    Validate the target user has specified permissions in chat
+    """
+    can_be_same: bool = False
+    can_be_bot: bool = False
+
+    def get_target_id(self, message: types.Message, _bot: Bot) -> Optional[int]:
+        target_user = get_target_user(message, self.can_be_same, self.can_be_bot)
+        if target_user is None:
+            return None
+        return target_user.id
 
 
 class BotHasPermissions(HasPermissions):
@@ -88,5 +107,5 @@ class BotHasPermissions(HasPermissions):
     }
     PAYLOAD_ARGUMENT_NAME = "bot_member"
 
-    def get_target_id(self, message: types.Message, bot: Bot) -> int:
+    def get_target_id(self, _message: types.Message, bot: Bot) -> Optional[int]:
         return bot.id

--- a/app/filters/tg_permissions.py
+++ b/app/filters/tg_permissions.py
@@ -71,7 +71,7 @@ class HasPermissions(Filter):
 
         return {self.PAYLOAD_ARGUMENT_NAME: chat_member}
 
-    def get_target_id(self, message: types.Message, _bot: Bot) -> Optional[int]:
+    def get_target_id(self, message: types.Message, bot: Bot) -> Optional[int]:
         return message.from_user.id
 
 
@@ -83,7 +83,7 @@ class TargetHasPermissions(HasPermissions):
     can_be_same: bool = False
     can_be_bot: bool = False
 
-    def get_target_id(self, message: types.Message, _bot: Bot) -> Optional[int]:
+    def get_target_id(self, message: types.Message, bot: Bot) -> Optional[int]:
         target_user = get_target_user(message, self.can_be_same, self.can_be_bot)
         if target_user is None:
             return None
@@ -107,5 +107,5 @@ class BotHasPermissions(HasPermissions):
     }
     PAYLOAD_ARGUMENT_NAME = "bot_member"
 
-    def get_target_id(self, _message: types.Message, bot: Bot) -> Optional[int]:
+    def get_target_id(self, message: types.Message, bot: Bot) -> Optional[int]:
         return bot.id

--- a/app/handlers/moderator.py
+++ b/app/handlers/moderator.py
@@ -125,7 +125,7 @@ async def cmd_ban(message: types.Message, user: User, target: User, chat: Chat, 
     HasPermissions(can_restrict_members=True),
     ~BotHasPermissions(can_restrict_members=True),
 )
-async def cmd_ro_no_bot_permissions(message: types.Message):
+async def cmd_ban_no_bot_permissions(message: types.Message):
     await message.reply("Мне нужны соответствующие права, чтобы блокировать пользователей в группе.")
 
 

--- a/app/handlers/moderator.py
+++ b/app/handlers/moderator.py
@@ -1,20 +1,21 @@
 import asyncio
 
-from aiogram import types, F, Bot, Router
+from aiogram import Bot, F, Router, types
 from aiogram.exceptions import TelegramUnauthorizedError
 from aiogram.filters import Command
 from aiogram.utils.text_decorations import html_decoration as hd
 
-from app.filters import HasTargetFilter, HasPermissions, BotHasPermissions
+from app.filters import BotHasPermissions, HasPermissions, HasTargetFilter
 from app.models.config import Config
 from app.models.db import Chat, User
-from app.services.moderation import warn_user, ro_user, ban_user, get_duration, delete_moderator_event
+from app.services.moderation import (ban_user, delete_moderator_event,
+                                     get_duration, ro_user, warn_user)
 from app.services.remove_message import delete_message, remove_kb
 from app.services.user_info import get_user_info
-from app.utils.exceptions import TimedeltaParseError, ModerationError
+from app.utils.exceptions import ModerationError, TimedeltaParseError
 from app.utils.log import Logger
-from . import keyboards as kb
 
+from . import keyboards as kb
 
 logger = Logger(__name__)
 router = Router(name=__name__)
@@ -30,6 +31,14 @@ async def report(message: types.Message, bot: Bot):
     answer_template = "Спасибо за сообщение. Мы обязательно разберёмся. "
     admins_mention = await get_mentions_admins(message.chat, bot)
     await message.reply(answer_template + admins_mention + " ")
+
+
+@router.message(
+    F.chat.type == "private",
+    Command('report', 'admin', 'spam', prefix="/!@"),
+)
+async def report_private(message: types.Message):
+    await message.reply("Вы можете жаловаться на сообщения пользователей только в группах.")
 
 
 async def get_mentions_admins(chat: types.Chat, bot: Bot):
@@ -48,6 +57,7 @@ def need_notify_admin(admin: types.ChatMemberAdministrator | types.ChatMemberOwn
 
 
 @router.message(
+    F.chat.type.in_(["group", "supergroup"]),
     HasTargetFilter(),
     Command(commands=["ro", "mute"], prefix="!"),
     HasPermissions(can_restrict_members=True),
@@ -68,6 +78,15 @@ async def cmd_ro(message: types.Message, user: User, target: User, chat: Chat, b
 
 
 @router.message(
+    F.chat.type == "private",
+    Command(commands=["ro", "mute"], prefix="!"),
+)
+async def cmd_ro_private(message: types.Message):
+    await message.reply("Вы можете запрещать писать пользователям только в группах.")
+
+
+@router.message(
+    F.chat.type.in_(["group", "supergroup"]),
     HasTargetFilter(),
     Command(commands=["ban"], prefix="!"),
     HasPermissions(can_restrict_members=True),
@@ -88,6 +107,15 @@ async def cmd_ban(message: types.Message, user: User, target: User, chat: Chat, 
 
 
 @router.message(
+    F.chat.type == "private",
+    Command(commands=["ban"], prefix="!"),
+)
+async def cmd_ban_private(message: types.Message):
+    await message.reply("Вы можете блоировать пользователей только в группах.")
+
+
+@router.message(
+    F.chat.type.in_(["group", "supergroup"]),
     HasTargetFilter(),
     Command(commands=["w", "warn"], prefix="!"),
     HasPermissions(can_restrict_members=True),
@@ -114,7 +142,18 @@ async def cmd_warn(message: types.Message, chat: Chat, target: User, user: User,
     asyncio.create_task(remove_kb(msg, config.time_to_cancel_actions))
 
 
-@router.message(HasTargetFilter(can_be_same=True), Command("info", prefix='!'))
+@router.message(
+    F.chat.type == "private",
+    Command(commands=["w", "warn"], prefix="!"),
+)
+async def cmd_warn_private(message: types.Message):
+    await message.reply("Вы можете выдавать предупреждения пользователям только в группах.")
+
+
+@router.message(
+    F.chat.type.in_(["group", "supergroup"]),
+    HasTargetFilter(can_be_same=True), Command("info", prefix='!'),
+)
 async def get_info_about_user(message: types.Message, chat: Chat, target: User, config: Config, bot: Bot):
     info = await get_user_info(target, chat, config.date_format)
     target_karma = await target.get_karma(chat)
@@ -138,6 +177,15 @@ async def get_info_about_user(message: types.Message, chat: Chat, target: User, 
 
 
 @router.message(
+    F.chat.type == "private",
+    Command("info", prefix='!'),
+)
+async def get_info_about_user_private(message: types.Message):
+    await message.reply("Вы можете запрашивать информацию о пользователях только в группах.")
+
+
+@router.message(
+    F.chat.type.in_(["group", "supergroup"]),
     HasTargetFilter(),
     Command(commands=["ro", "mute", "ban"], prefix="!"),
     HasPermissions(can_restrict_members=True),
@@ -148,6 +196,7 @@ async def cmd_ro_bot_not_admin(message: types.Message):
 
 
 @router.message(
+    F.chat.type.in_(["group", "supergroup"]),
     Command(commands=["ro", "mute", "ban", "warn", "w"], prefix="!"),
     BotHasPermissions(can_delete_messages=True),
 )


### PR DESCRIPTION
Add new filter to check target user permissions. Invert this filter and sets it for moderator commands allows you to fix #99.

Add new handlers `cmd_ro_no_bot_permissions`, `cmd_ban_no_bot_permissions` that replace common handler that notifies about insufficient bot permissions, which processed unhandled for `ro` and `ban`. Using such a handler is very implicit and leads to the fact that it is necessary to invert the newly added filters. 